### PR TITLE
fix: Correção de erros de versão

### DIFF
--- a/org.idempierelbr.nfe/META-INF/MANIFEST.MF
+++ b/org.idempierelbr.nfe/META-INF/MANIFEST.MF
@@ -64,7 +64,7 @@ Bundle-ClassPath: .,
  lib/axis2/wsdl4j-1.6.2.jar,
  lib/axis2/XmlSchema-1.4.7.jar,
  lib/axis2/axiom-impl-1.2.13.jar,
- lib/xstream-1.4.7.jar,
+ lib/xstream-1.4.20.jar,
  lib/axis2/mail-1.4.jar,
  lib/javase-1.3.4.jar
 Bundle-ActivationPolicy: lazy

--- a/org.idempierelbr.nfe/build.properties
+++ b/org.idempierelbr.nfe/build.properties
@@ -15,7 +15,7 @@ bin.includes = META-INF/,\
                lib/axis2/wsdl4j-1.6.2.jar,\
                lib/axis2/XmlSchema-1.4.7.jar,\
                lib/axis2/axiom-impl-1.2.13.jar,\
-               lib/xstream-1.4.7.jar,\
+               lib/xstream-1.4.20.jar,\
                lib/axis2/mail-1.4.jar,\
                lib/javase-1.3.4.jar,\
                OSGI-INF/

--- a/org.idempierelbr.nfe/pom.xml
+++ b/org.idempierelbr.nfe/pom.xml
@@ -42,8 +42,8 @@
                 <artifactItem>
                   <groupId>com.thoughtworks.xstream</groupId>
                   <artifactId>xstream</artifactId>
-                  <version>1.4.7</version>
-                  <destFileName>xstream-1.4.7.jar</destFileName>
+                  <version>1.4.20</version>
+                  <destFileName>xstream-1.4.20.jar</destFileName>
                 </artifactItem>
                 <artifactItem>
                   <groupId>com.google.zxing</groupId>


### PR DESCRIPTION
Durante o processo de criação/finalização da NFe, na classe NfeXMLGenerator.java gerava-se um erro java.lang.NoClassDefFoundError: Could not ... TreeMapConverter. Isso se dá pois a versão do xstream antiga não compreendia alterações a partir do java 9, e com a atualização de versão para java 17 isso precisa ser adequado.