### PR TITLE
feat: Adicionando preenchimento LBR_ICMSST_TaxRate

### DIFF
--- a/org.idempierelbr.base/src/org/idempierelbr/base/model/MLBRDocLineDetails.java
+++ b/org.idempierelbr.base/src/org/idempierelbr/base/model/MLBRDocLineDetails.java
@@ -422,6 +422,7 @@ public class MLBRDocLineDetails extends X_LBR_DocLine_Details
 			
 			icms.setLBR_ICMSST_TaxBAmtWhd(tl.getLBR_TaxBaseAmt());
 			icms.setLBR_ICMSST_TaxAmtWhd(tl.getLBR_TaxAmt());
+			icms.setLBR_ICMSST_TaxRate(tl.getLBR_TaxRate());
 		}
 		
 		if (TextUtil.match (taxStatus,


### PR DESCRIPTION
Não foi possível gerar a NF através da classe NfeLineUtil para o CST ICMS60 sem que o TaxRate estivesse preenchido.