### PR TITLE
adicionar param adclient_id na query de procurar ad_attachment

### DIFF
--- a/org.idempierelbr.nfe/src/org/idempierelbr/nfe/apps/form/NFFromXMLGen.java
+++ b/org.idempierelbr.nfe/src/org/idempierelbr/nfe/apps/form/NFFromXMLGen.java
@@ -676,7 +676,9 @@ public class NFFromXMLGen
 			params.add(nf.Table_ID);
 			if (nf.get_ID() > 0) {
 				whereClause.append(" AND Record_ID=?");
+				whereClause.append(" AND AD_Client_ID=?");
 				params.add(nf.get_ID());
+				params.add(nf.getAD_Client_ID());
 			}
 			int AD_Attachment_ID = DB.getSQLValueEx(trxName, whereClause.toString(), params);
 			MAttachment attachNFe = null;


### PR DESCRIPTION
na classe da janela de gerar nf via xml, existe um método onde é procurado um attachment existente, e se não houver, criar um novo, o que esta acontecendo é que ele esta achando um registro de outro client e isso está ocasionando cross tenant.