### PR TITLE
IDEMPIERE-7069: declare support for tax-included price list with summary tax

### DIFF
--- a/org.idempierelbr.tax/src/org/idempierelbr/tax/provider/DefaultTaxProvider.java
+++ b/org.idempierelbr.tax/src/org/idempierelbr/tax/provider/DefaultTaxProvider.java
@@ -1154,6 +1154,16 @@ public class DefaultTaxProvider implements ITaxProvider {
 		s_log.log(Level.SEVERE, "DefaultTaxProvider: validateConnection(MTaxProvider provider, ProcessInfo pi)");
 		return null;
 	}
+
+	/**
+	 * LBR delegates the whole tax calculation and computes tax-included summary taxes from its own
+	 * detail tables, so it handles this case correctly (see IDEMPIERE-6749 / IDEMPIERE-7069).
+	 */
+	@Override
+	public boolean isTaxIncludedSummarySupported()
+	{
+		return true;
+	}
 	
 	/**
 	 * Recalculate invoice tax


### PR DESCRIPTION
Related to https://idempiere.atlassian.net/browse/IDEMPIERE-7069
Depends on iDempiere core PR https://github.com/idempiere/idempiere/pull/3317

## Context

The iDempiere core (IDEMPIERE-6749) forbids saving order/invoice lines when the price list is tax-included and the tax is a Summary tax, because the native `StandardTaxProvider` miscalculates that combination.

IDEMPIERE-7069 turns that block into an opt-in capability on `ITaxProvider`: `isTaxIncludedSummarySupported()`, default `false`.

## Change

The LBR `DefaultTaxProvider` delegates the whole tax calculation and computes tax-included summary taxes from its own detail tables (ICMS, PIS, COFINS, IPI, IBS/CBS, ...), so it is not affected by the native bug. This PR overrides `isTaxIncludedSummarySupported()` to return `true`, allowing tax-included price lists with summary taxes to be saved when handled by the LBR provider.

## Note

Requires the `ITaxProvider.isTaxIncludedSummarySupported()` method added by core PR #3317. It must be present in the iDempiere version this builds against (release-13), so merge this only after the core change is available there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
