### PR TITLE
chore(test): commit shared launch config for LBR integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,5 +55,20 @@ Você pode então fazer build do projeto com o comando:
 Ao finalizar, você já pode importar os projetos do LBR no eclipse.
 
 
+## Executando os testes de integração
+
+Os testes de integração do LBR (arquivos `*IT.java` em `org.idempierelbr.test`) são executados como **JUnit Plug-in Test** no Eclipse. O projeto inclui um arquivo `.launch` pré-configurado que já contém todas as configurações necessárias — incluindo os bundles OSGi (`org.eclipse.equinox.event`, `org.apache.felix.scr`) sem os quais o `Adempiere.startup` trava indefinidamente aguardando o `EventManager`.
+
+Para executar:
+
+1. Importe os projetos LBR no Eclipse (após seguir a instalação acima).
+2. Abra o arquivo `org.idempierelbr.test/org.idempierelbr.test.launch` no navegador de projetos.
+3. Clique com o botão direito → **Run As → org.idempierelbr.test**.
+
+O arquivo `.launch` usa `${project_loc:org.adempiere.base}/..` para resolver o `IDEMPIERE_HOME` a partir do workspace, então funciona em qualquer máquina desde que o `org.adempiere.base` esteja importado.
+
+Ao criar novos arquivos `.launch` de teste, mantenha `automaticAdd=true` e `automaticIncludeRequirements=true` para que o Eclipse resolva automaticamente as dependências OSGi.
+
+
 ## Agradecimentos
 Devemos reconhecer o esforço de todos os colaboradores deste projeto e dos antecessores, especialmente o time ADempiereLBR. Sabemos das longas horas investidas para adaptar este incrível ERP à realidade brasileira. Cabe mencionar que em todas as classes trazidas ao projeto iDempiereLBR, mantivemos a referência dos autores das mesmas.

--- a/org.idempierelbr.test/org.idempierelbr.test.launch
+++ b/org.idempierelbr.test/org.idempierelbr.test.launch
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.pde.ui.JunitLaunchConfig">
+    <stringAttribute key="application" value="org.eclipse.pde.junit.runtime.coretestapplication"/>
+    <booleanAttribute key="askclear" value="false"/>
+    <booleanAttribute key="automaticAdd" value="true"/>
+    <booleanAttribute key="automaticIncludeRequirements" value="true"/>
+    <booleanAttribute key="automaticValidate" value="false"/>
+    <booleanAttribute key="clearConfig" value="true"/>
+    <booleanAttribute key="clearws" value="true"/>
+    <booleanAttribute key="clearwslog" value="false"/>
+    <stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/pde-junit"/>
+    <booleanAttribute key="default" value="true"/>
+    <booleanAttribute key="includeOptional" value="true"/>
+    <stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/org.idempierelbr.test"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="4"/>
+    </listAttribute>
+    <stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=org.idempierelbr.test"/>
+    <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
+    <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
+    <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit5"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value=""/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.idempierelbr.test"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-DIDEMPIERE_HOME=${project_loc:org.adempiere.base}/.."/>
+    <stringAttribute key="pde.version" value="3.3"/>
+    <stringAttribute key="product" value="org.eclipse.sdk.ide"/>
+    <booleanAttribute key="run_in_ui_thread" value="false"/>
+    <stringAttribute key="templateConfig" value=""/>
+    <booleanAttribute key="tracing" value="false"/>
+    <booleanAttribute key="useCustomFeatures" value="false"/>
+    <booleanAttribute key="useDefaultConfig" value="true"/>
+    <booleanAttribute key="useDefaultConfigArea" value="true"/>
+    <booleanAttribute key="useProduct" value="false"/>
+</launchConfiguration>


### PR DESCRIPTION
## Summary

When cloning the workspace and importing the iDempiereLBR projects for the first time, running any integration test via **JUnit Plug-in Test** (Eclipse's default) results in a silent hang: the test prints `Running <name>()` to the console and blocks indefinitely — no error, no stack trace, JVM doesn't terminate on its own.

Root cause is `EventManager.getInstance()` inside `Adempiere.startup` sitting in `Object.wait()` waiting for the OSGi `EventAdmin` service to bind — a service provided by the `org.eclipse.equinox.event` bundle, which Eclipse's auto-generated JUnit Plug-in Test launch configs don't include by default. Symptoms are non-deterministic ("random hangs", "only one test runs", "hangs in a different place each time"), and diagnosing it from scratch consumes hours per developer.

This PR ships a launch configuration that resolves the required bundles automatically, so any developer cloning the repo gets a working setup on first attempt.

## What changed

- **`org.idempierelbr.test/org.idempierelbr.test.launch`** (new) — shared JUnit Plug-in Test launch config with:
- `automaticAdd=true` + `automaticIncludeRequirements=true` — Eclipse resolves all workspace bundles and their OSGi requirements, including `org.eclipse.equinox.event` (EventAdmin).
- `IDEMPIERE_HOME` set via `${project_loc:org.adempiere.base}/..` — machine-independent; works on any workspace where `org.adempiere.base` is imported.
- **`README.md`** — new "Executando os testes de integração" section explaining how to run the tests and what the `.launch` file does.

Zero production-code changes. Doesn't affect existing launch configs any developer already has locally.