### PR TITLE
Gera o grupo ICMSUFDest também na NF-e de devolução

### DIFF
--- a/org.idempierelbr.nfe/src/org/idempierelbr/nfe/util/NFeLineUtil.java
+++ b/org.idempierelbr.nfe/src/org/idempierelbr/nfe/util/NFeLineUtil.java
@@ -1269,10 +1269,11 @@ public class NFeLineUtil {
 	 */
 	public ICMSUFDestBean getICMSDIFAL() {
 		
-		// nfe, emitido pela org, saida, consumidor final e interstadual
+		// nfe, emitido pela org, saida (ou entrada de devolucao/retorno), consumidor final e interstadual
 		if (!line.getParent().getLBR_NFeModel().equals(MLBRNotaFiscal.LBR_NFEMODEL_55_NF_E)
 				|| !line.getParent().isLBR_IsDocIssuedByOrg()
-				|| !line.getParent().getLBR_NFE_OperationType().equals(MLBRNotaFiscal.LBR_NFE_OPERATIONTYPE_Out)
+				|| !(line.getParent().getLBR_NFE_OperationType().equals(MLBRNotaFiscal.LBR_NFE_OPERATIONTYPE_Out)
+						|| line.getParent().getLBR_FinNFe().equals(MLBRNotaFiscal.LBR_FINNFE_DevolucaoRetorno))
 				|| !line.getParent().getLBR_NFeIndFinal().equals(MLBRNotaFiscal.LBR_NFEINDFINAL_EndConsumer)
 				|| !line.getParent().getLBR_NFE_DestinationType().equals(MLBRNotaFiscal.LBR_NFE_DESTINATIONTYPE_OperacaoInterestadual))
 			return null;


### PR DESCRIPTION
A NF-e de devolução (tpNF=0, finNFe=4) interestadual a consumidor final não contribuinte era rejeitada com 799 ("Valor total do ICMS Interestadual da UF de destino difere do somatório dos itens") e 798 (idem para a UF do remetente).

getICMSDIFAL() só montava o grupo ICMSUFDest quando LBR_NFE_OperationType era saída, enquanto MLBRNotaFiscal.getTotalTaxAmtDifalDest/Remet/FCP() somam o DIFAL de todas as linhas para o ICMSTot, sem esse filtro. Na devolução as linhas herdam o DIFAL da venda original, então o total saía preenchido e a soma dos itens ficava zerada.

Passa a aceitar também LBR_FINNFE_DevolucaoRetorno na condição do item, como exige a NT 2015.003. As demais condições (modelo 55, emitida pela org, consumidor final, interestadual, CST 00/CSOSN 101 e DIFAL > 0) seguem delimitando o escopo, e a devolução de compra continua entrando pelo ramo de saída.
