### PR TITLE
feat(nfe): ganchos de extensão na importação de DF-e

### DIFF
--- a/org.idempierelbr.nfe/META-INF/MANIFEST.MF
+++ b/org.idempierelbr.nfe/META-INF/MANIFEST.MF
@@ -18,7 +18,8 @@ Require-Bundle: org.adempiere.base,
  zkwebfragment,
  org.idempierelbr.base
 Service-Component: OSGI-INF/*.xml
-Export-Package: org.idempierelbr.nfe.beans,
+Export-Package: org.idempierelbr.nfe.apps.form,
+ org.idempierelbr.nfe.beans,
  org.idempierelbr.nfe.imports,
  org.idempierelbr.nfe.model,
  org.idempierelbr.nfe.process,

--- a/org.idempierelbr.nfe/src/org/idempierelbr/nfe/apps/form/WNFeImportDFe.java
+++ b/org.idempierelbr.nfe/src/org/idempierelbr/nfe/apps/form/WNFeImportDFe.java
@@ -145,7 +145,8 @@ public class WNFeImportDFe implements IFormController, EventListener<Event>, Val
 	/** Produtos sugeridos para a pendência em foco */
 	private final List<MProduct> suggestions = new ArrayList<MProduct>();
 
-	private final NFeImportOptions options = new NFeImportOptions();
+	/** Opções do lote; uma subclasse pode trocar por uma especialização no seu construtor */
+	protected NFeImportOptions options = new NFeImportOptions();
 
 	private Listbox orgPicker;
 	private Listbox documentList;
@@ -172,7 +173,7 @@ public class WNFeImportDFe implements IFormController, EventListener<Event>, Val
 
 	public void initForm() {
 		try {
-			readService = new NFeImportService(Env.getCtx(), null);
+			readService = newService(null);
 			jbInit();
 		} catch (Exception e) {
 			// engolir a falha aqui abriria uma aba vazia, sem explicação nenhuma
@@ -189,6 +190,11 @@ public class WNFeImportDFe implements IFormController, EventListener<Event>, Val
 
 	private int getWindowNo() {
 		return form.getWindowNo();
+	}
+
+	/** Fábrica do serviço de importação, para uma subclasse devolver a sua especialização */
+	protected NFeImportService newService(String trxName) {
+		return new NFeImportService(Env.getCtx(), trxName);
 	}
 
 	// -------------------------------------------------------------------------
@@ -288,7 +294,7 @@ public class WNFeImportDFe implements IFormController, EventListener<Event>, Val
 	 * O que vale para o lote inteiro. Cada nota pode ser importada com outro
 	 * tipo de documento, mas o normal é o lote inteiro compartilhar a decisão.
 	 */
-	private Grid createOptionsGrid() {
+	protected Grid createOptionsGrid() {
 		Grid grid = GridFactory.newGridLayout();
 
 		Columns columns = new Columns();
@@ -351,7 +357,7 @@ public class WNFeImportDFe implements IFormController, EventListener<Event>, Val
 		return grid;
 	}
 
-	private void appendRow(Rows rows, String label, WEditor editor, boolean mandatory) {
+	protected void appendRow(Rows rows, String label, WEditor editor, boolean mandatory) {
 		Row row = new Row();
 		Label text = new Label(label);
 
@@ -972,7 +978,7 @@ public class WNFeImportDFe implements IFormController, EventListener<Event>, Val
 			Trx trx = Trx.get(trxName, true);
 
 			try {
-				NFeImportService service = new NFeImportService(Env.getCtx(), trxName);
+				NFeImportService service = newService(trxName);
 				String blocker = service.validate(nfe, options);
 
 				if (blocker != null) {

--- a/org.idempierelbr.nfe/src/org/idempierelbr/nfe/imports/NFeImportService.java
+++ b/org.idempierelbr.nfe/src/org/idempierelbr/nfe/imports/NFeImportService.java
@@ -326,6 +326,8 @@ public class NFeImportService {
 
 			reconcileDFe(nf, nfe);
 
+			afterImport(nf, nfe, options);
+
 			if (!DocAction.ACTION_None.equals(options.docAction))
 				process(nf, options.docAction);
 
@@ -333,6 +335,10 @@ public class NFeImportService {
 		} finally {
 			current = null;
 		}
+	}
+
+	/** Gancho com a nota já conciliada e ainda em rascunho, na transação do chamador */
+	protected void afterImport(MLBRNotaFiscal nf, NFeImportDocument nfe, NFeImportOptions options) {
 	}
 
 	/**


### PR DESCRIPTION
## Por que

O Monitor DF-e resolveu a aquisição e a conciliação, mas a importação ficou
fechada: `WNFeImportDFe` e `NFeImportService` não têm nenhum ponto de extensão.

| | linhas | `private` | `public` | `protected` |
|---|---|---|---|---|
| `WNFeImportDFe` | 1153 | 41 | 6 | **0** |
| `NFeImportService` | 2016 | 43 | 6 | **0** |

Além disso, `org.idempierelbr.nfe.apps.form` não está no `Export-Package` do
MANIFEST, então um bundle externo não resolve nem o `import` da tela.

Isso é um problema concreto para qualquer instalação em que a nota de entrada
não é o fim do processo, e sim o começo dele. Uma nota fiscal de terceiro
costuma implicar outros documentos — pedido, recebimento, fatura — e cada
empresa encadeia os seus de um jeito. Hoje o único caminho para isso é
**duplicar as duas classes inteiras (3169 linhas)** e manter a cópia em sincronia
a cada correção que entrar aqui. É o que estamos tentando não fazer.

Os pontos que um consumidor precisa alcançar são quatro, e nenhum deles é
alcançável hoje:

1. herdar a tela;
2. acrescentar campos ao grid "Dados do lote";
3. injetar uma especialização de `NFeImportOptions` (com `validate()` próprio,
   rodando **antes de qualquer `Trx` abrir**) e de `NFeImportService`;
4. rodar código próprio com a nota já criada, **ainda em rascunho**, dentro da
   transação do chamador — para que uma falha no que for encadeado reverta a
   nota junto, em vez de deixar uma NF de entrada sem o recebimento
   correspondente.

## O que muda

3 arquivos, **+19/−6**. Nenhum comportamento novo.

| Mudança | Por quê |
|---|---|
| `MANIFEST`: exporta `org.idempierelbr.nfe.apps.form` | sem isso nada mais importa |
| `options` deixa de ser `private final` → `protected` | a subclasse troca a instância no construtor; `options.validate()` continua rodando em `doImport`, antes de abrir transação |
| `+ protected NFeImportService newService(String trxName)` | o serviço é construído **por transação** dentro do laço privado de `doImport`; nenhum campo alcança esse ponto, só uma fábrica |
| `createOptionsGrid()` e `appendRow(...)` → `protected` | a subclasse chama `super`, pega as linhas do `Grid` devolvido e acrescenta as suas |
| `+ protected void afterImport(nf, nfe, options)` | chamado depois de `reconcileDFe` e **antes** de `process`, com a nota em rascunho e na transação do chamador |

`afterImport` precisa ser anterior ao `process` justamente por causa do ponto 4:
sobrescrever o `importDocument` público não serve, porque quando ele retorna a
nota já foi processada se `docAction != None`, e nota completada não aceita mais
alteração de cabeçalho.

## O que deliberadamente não entrou

Uma primeira versão deste patch tinha 7 ganchos. Quatro se mostraram
desnecessários e foram cortados:

- **gancho de evento** — `onEvent` já é `public` e despacha por `id`. A
  subclasse sobrescreve, trata o que é seu e delega ao `super`.
- **`appendExtraOptions(Rows)`** — `createOptionsGrid()` devolve o `Grid`;
  elevá-lo a `protected` cobre o caso sem método novo.
- **`getWindowNo()` → `protected`** — `getForm().getWindowNo()` é a mesma
  chamada, e `getForm()` já é `public`.
- **`newOptions()`** — um campo `protected` não-`final` resolve, já que as
  opções são uma instância única do lote (ao contrário do serviço).

## Compatibilidade

Nenhuma alteração de comportamento. Todos os pontos ou ampliam visibilidade, ou
são um método vazio, ou são uma fábrica que devolve exatamente o que a chamada
construía inline. O fluxo atual da tela é idêntico.

## Nota para quem consumir

`Grid.getRows()` devolve `org.zkoss.zul.Rows`, e o grid é montado com o `Rows`
do iDempiere — a subclasse precisa do cast. Não muda nada aqui, mas economiza
uma ida ao compilador.

## Verificação

- `javac` nos dois arquivos alterados, com o classpath dos bundles p2, dos
  `target/classes` do workspace iDempiere e dos jars de `*/lib`. `EXIT=0`.
- Subclasse descartável **fora do pacote**, compilada contra as classes
  corrigidas, exercitando os quatro pontos acima: herda a tela, acrescenta linha
  ao grid via `super.createOptionsGrid()` + `appendRow`, injeta subclasses de
  `NFeImportOptions` (com `copy()` covariante e `validate()` próprio) e de
  `NFeImportService`, e recebe a nota em `afterImport` afirmando
  `DOCSTATUS_Drafted`. `EXIT=0`. Protótipo de verificação, não entra no PR.
- Sem teste automatizado: o diff não acrescenta comportamento, e o único
  contrato de runtime que valeria fixar (a ordem do `afterImport`) exige o
  `importDocument` de ponta a ponta, com banco — é IT, e pertence a quem
  consumir o gancho.